### PR TITLE
Allow newer versions of Faraday

### DIFF
--- a/cloudflair.gemspec
+++ b/cloudflair.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w(lib)
 
-  spec.add_runtime_dependency 'faraday'
+  spec.add_runtime_dependency 'faraday', '>= 0.10.0', '< 0.13'
   spec.add_runtime_dependency 'faraday_middleware'
   spec.add_runtime_dependency 'dry-configurable', '~> 0.1'
   spec.add_runtime_dependency 'faraday-detailed_logger'

--- a/cloudflair.gemspec
+++ b/cloudflair.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w(lib)
 
-  spec.add_runtime_dependency 'faraday', '~> 0.9.0'
-  spec.add_runtime_dependency 'faraday_middleware', '~> 0.10.0'
+  spec.add_runtime_dependency 'faraday'
+  spec.add_runtime_dependency 'faraday_middleware'
   spec.add_runtime_dependency 'dry-configurable', '~> 0.1'
-  spec.add_runtime_dependency 'faraday-detailed_logger', '~> 2.1'
+  spec.add_runtime_dependency 'faraday-detailed_logger'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Current faraday (0.9.x) is locked to a version more than 1 year old, newest version is 0.12.x.

From their changelog, 0.10 and up introduce only one breaking change: removal of ruby 1.8.x support. Seems like cloudflair is not supporting that version anyway, so updating the faraday version should not break anything.