### PR TITLE
Add the new authentication header in Cloudflare v4

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,38 @@
+require:
+  - rubocop-performance
+  - rubocop-rspec
+
+AllCops:
+  Exclude:
+    - 'bin/**/*'
+    - 'db/**/*'
+  TargetRubyVersion: 2.6.1
+
+Layout/AlignHash:
+  EnforcedColonStyle: table
+  EnforcedHashRocketStyle: table
+
+Metrics/BlockLength:
+  Exclude:
+    - Guardfile
+    - 'spec/**/*spec.rb'
+
+Metrics/LineLength:
+  Exclude:
+    - Guardfile
+  Max: 110
+
+Rails:
+  Enabled: true
+
+Rails/HttpPositionalArguments:
+  Exclude:
+
+Rails/SkipsModelValidations:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+Style/Documentation:
+  Enabled: false

--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+cloudflair

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in cloudflair.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 

--- a/cloudflair.gemspec
+++ b/cloudflair.gemspec
@@ -1,6 +1,6 @@
-# coding: utf-8
+# frozen_string_literal: true
 
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'cloudflair/version'
 
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.name          = 'cloudflair'
   spec.version       = File.read('VERSION')
   spec.authors       = ['Christian Mäder']
-  spec.email         = %w(christian.maeder@nine.ch)
+  spec.email         = %w[christian.maeder@nine.ch]
 
   spec.summary       = "Wrapper to CloudFlare's v4 REST API."
   spec.description   = "Cloudflair aims to provide easy access to CloudFlare's public API."
@@ -22,15 +22,16 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w[lib]
 
-  spec.add_runtime_dependency 'faraday', '>= 0.10.0'
-  spec.add_runtime_dependency 'faraday_middleware'
   spec.add_runtime_dependency 'dry-configurable', '~> 0.1'
+  spec.add_runtime_dependency 'faraday', '>= 0.10.0'
   spec.add_runtime_dependency 'faraday-detailed_logger'
+  spec.add_runtime_dependency 'faraday_middleware'
 
   spec.add_development_dependency 'bundler', '~> 2.0.0'
+  spec.add_development_dependency 'dotenv', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
-  spec.add_development_dependency 'dotenv', '~> 2.1'
   spec.add_development_dependency 'rubocop', '~> 0.48'
+  spec.add_development_dependency 'rubocop-performance'
   spec.add_development_dependency 'rubocop-rspec', '~> 1.15'
 end

--- a/lib/cloudflair.rb
+++ b/lib/cloudflair.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/api'
 require 'cloudflair/version'
 require 'dry-configurable'

--- a/lib/cloudflair/api.rb
+++ b/lib/cloudflair/api.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/api/zone'
 require 'cloudflair/api/railguns'
 require 'cloudflair/communication'

--- a/lib/cloudflair/api/railguns.rb
+++ b/lib/cloudflair/api/railguns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone.rb
+++ b/lib/cloudflair/api/zone.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/api/zone/analytics'
 require 'cloudflair/api/zone/available_plan'
 require 'cloudflair/api/zone/available_rate_plan'

--- a/lib/cloudflair/api/zone/analytics.rb
+++ b/lib/cloudflair/api/zone/analytics.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/available_plan.rb
+++ b/lib/cloudflair/api/zone/available_plan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/available_rate_plan.rb
+++ b/lib/cloudflair/api/zone/available_rate_plan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/custom_hostname.rb
+++ b/lib/cloudflair/api/zone/custom_hostname.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/dns_record.rb
+++ b/lib/cloudflair/api/zone/dns_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/dns_record.rb
+++ b/lib/cloudflair/api/zone/dns_record.rb
@@ -8,6 +8,7 @@ module Cloudflair
 
     attr_reader :zone_id, :record_id
     deletable true
+    patchable_fields :content
     path 'zones/:zone_id/dns_records/:record_id'
 
     def initialize(zone_id, record_id)

--- a/lib/cloudflair/api/zone/purge_cache.rb
+++ b/lib/cloudflair/api/zone/purge_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/communication'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/railgun.rb
+++ b/lib/cloudflair/api/zone/railgun.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings.rb
+++ b/lib/cloudflair/api/zone/settings.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/api/zone/settings/advanced_ddos'
 require 'cloudflair/api/zone/settings/always_online'
 require 'cloudflair/api/zone/settings/browser_cache_ttl'
@@ -38,36 +40,36 @@ module Cloudflair
     end
 
     {
-      advanced_ddos: Cloudflair::AdvancedDdos,
-      always_online: Cloudflair::AlwaysOnline,
-      browser_cache_ttl: Cloudflair::BrowserCacheTtl,
-      browser_check: Cloudflair::BrowserCheck,
-      cache_level: Cloudflair::CacheLevel,
-      challenge_ttl: Cloudflair::ChallengeTtl,
-      development_mode: Cloudflair::DevelopmentMode,
-      email_obfuscation: Cloudflair::EmailObfuscation,
-      hotlink_protection: Cloudflair::HotlinkProtection,
-      ip_geolocation: Cloudflair::IpGeolocation,
-      ipv6: Cloudflair::Ipv6,
-      minify: Cloudflair::Minify,
-      mirage: Cloudflair::Mirage,
-      mobile_redirect: Cloudflair::MobileRedirect,
+      advanced_ddos:               Cloudflair::AdvancedDdos,
+      always_online:               Cloudflair::AlwaysOnline,
+      browser_cache_ttl:           Cloudflair::BrowserCacheTtl,
+      browser_check:               Cloudflair::BrowserCheck,
+      cache_level:                 Cloudflair::CacheLevel,
+      challenge_ttl:               Cloudflair::ChallengeTtl,
+      development_mode:            Cloudflair::DevelopmentMode,
+      email_obfuscation:           Cloudflair::EmailObfuscation,
+      hotlink_protection:          Cloudflair::HotlinkProtection,
+      ip_geolocation:              Cloudflair::IpGeolocation,
+      ipv6:                        Cloudflair::Ipv6,
+      minify:                      Cloudflair::Minify,
+      mirage:                      Cloudflair::Mirage,
+      mobile_redirect:             Cloudflair::MobileRedirect,
       origin_error_page_pass_thru: Cloudflair::OriginErrorPagePassThru,
-      polish: Cloudflair::Polish,
-      prefetch_preload: Cloudflair::PrefetchPreload,
-      response_buffering: Cloudflair::ResponseBuffering,
-      rocket_loader: Cloudflair::RocketLoader,
-      security_header: Cloudflair::SecurityHeader,
-      security_level: Cloudflair::SecurityLevel,
-      server_side_exclude: Cloudflair::ServerSideExclude,
+      polish:                      Cloudflair::Polish,
+      prefetch_preload:            Cloudflair::PrefetchPreload,
+      response_buffering:          Cloudflair::ResponseBuffering,
+      rocket_loader:               Cloudflair::RocketLoader,
+      security_header:             Cloudflair::SecurityHeader,
+      security_level:              Cloudflair::SecurityLevel,
+      server_side_exclude:         Cloudflair::ServerSideExclude,
       sort_query_string_for_cache: Cloudflair::SortQueryStringForCache,
-      ssl: Cloudflair::Ssl,
-      tls_client_auth: Cloudflair::TlsClientAuth,
-      tls_1_2_only: Cloudflair::Tls12Only,
-      tls_1_3: Cloudflair::Tls13,
-      true_client_ip_header: Cloudflair::TrueClientIpHeader,
-      waf: Cloudflair::Waf,
-      websockets: Cloudflair::Websockets,
+      ssl:                         Cloudflair::Ssl,
+      tls_client_auth:             Cloudflair::TlsClientAuth,
+      tls_1_2_only:                Cloudflair::Tls12Only,
+      tls_1_3:                     Cloudflair::Tls13,
+      true_client_ip_header:       Cloudflair::TrueClientIpHeader,
+      waf:                         Cloudflair::Waf,
+      websockets:                  Cloudflair::Websockets
     }.each do |method, klass|
       define_method method do
         klass.new @zone_id

--- a/lib/cloudflair/api/zone/settings/advanced_ddos.rb
+++ b/lib/cloudflair/api/zone/settings/advanced_ddos.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/always_online.rb
+++ b/lib/cloudflair/api/zone/settings/always_online.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/browser_cache_ttl.rb
+++ b/lib/cloudflair/api/zone/settings/browser_cache_ttl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/browser_check.rb
+++ b/lib/cloudflair/api/zone/settings/browser_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/cache_level.rb
+++ b/lib/cloudflair/api/zone/settings/cache_level.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/challenge_ttl.rb
+++ b/lib/cloudflair/api/zone/settings/challenge_ttl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/development_mode.rb
+++ b/lib/cloudflair/api/zone/settings/development_mode.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/email_obfuscation.rb
+++ b/lib/cloudflair/api/zone/settings/email_obfuscation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/hotlink_protection.rb
+++ b/lib/cloudflair/api/zone/settings/hotlink_protection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/ip_geolocation.rb
+++ b/lib/cloudflair/api/zone/settings/ip_geolocation.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/ipv6.rb
+++ b/lib/cloudflair/api/zone/settings/ipv6.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/minify.rb
+++ b/lib/cloudflair/api/zone/settings/minify.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/mirage.rb
+++ b/lib/cloudflair/api/zone/settings/mirage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/mobile_redirect.rb
+++ b/lib/cloudflair/api/zone/settings/mobile_redirect.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/origin_error_page_pass_thru.rb
+++ b/lib/cloudflair/api/zone/settings/origin_error_page_pass_thru.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/polish.rb
+++ b/lib/cloudflair/api/zone/settings/polish.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/prefetch_preload.rb
+++ b/lib/cloudflair/api/zone/settings/prefetch_preload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/response_buffering.rb
+++ b/lib/cloudflair/api/zone/settings/response_buffering.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/rocket_loader.rb
+++ b/lib/cloudflair/api/zone/settings/rocket_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/security_header.rb
+++ b/lib/cloudflair/api/zone/settings/security_header.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/security_level.rb
+++ b/lib/cloudflair/api/zone/settings/security_level.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/server_side_exclude.rb
+++ b/lib/cloudflair/api/zone/settings/server_side_exclude.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/sort_query_string_for_cache.rb
+++ b/lib/cloudflair/api/zone/settings/sort_query_string_for_cache.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/ssl.rb
+++ b/lib/cloudflair/api/zone/settings/ssl.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/tls_1_2_only.rb
+++ b/lib/cloudflair/api/zone/settings/tls_1_2_only.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/tls_1_3.rb
+++ b/lib/cloudflair/api/zone/settings/tls_1_3.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/tls_client_auth.rb
+++ b/lib/cloudflair/api/zone/settings/tls_client_auth.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/true_client_ip_header.rb
+++ b/lib/cloudflair/api/zone/settings/true_client_ip_header.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/waf.rb
+++ b/lib/cloudflair/api/zone/settings/waf.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone/settings/websockets.rb
+++ b/lib/cloudflair/api/zone/settings/websockets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/entity'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone__available_plans.rb
+++ b/lib/cloudflair/api/zone__available_plans.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/api/zone/available_plan'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone__custom_hostnames.rb
+++ b/lib/cloudflair/api/zone__custom_hostnames.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/api/zone/custom_hostname'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone__dns_records.rb
+++ b/lib/cloudflair/api/zone__dns_records.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/api/zone/dns_record'
 
 module Cloudflair

--- a/lib/cloudflair/api/zone__dns_records.rb
+++ b/lib/cloudflair/api/zone__dns_records.rb
@@ -6,7 +6,6 @@ module Cloudflair
   class Zone
     def dns_records(filter = {})
       raw_records = response connection.get("#{path}/dns_records", filter)
-
       raw_records.map { |raw_record| build_dns_record(raw_record) }
     end
 
@@ -16,7 +15,6 @@ module Cloudflair
 
     def new_dns_record(record_data)
       raw_record = response connection.post("#{path}/dns_records", record_data)
-
       build_dns_record raw_record
     end
 

--- a/lib/cloudflair/api/zone__railguns.rb
+++ b/lib/cloudflair/api/zone__railguns.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/api/zone/railgun'
 
 module Cloudflair

--- a/lib/cloudflair/communication.rb
+++ b/lib/cloudflair/communication.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'cloudflair/error/cloudflare_error'
 require 'cloudflair/error/cloudflair_error'
 require 'cloudflair/connection'
@@ -35,8 +37,9 @@ module Cloudflair
       body = response.body
 
       unless body['success']
-        fail Cloudflair::CloudflairError, "Unrecognized response format: '#{body}'" unless body['errors']
-        fail Cloudflair::CloudflareError, body['errors']
+        raise Cloudflair::CloudflairError, "Unrecognized response format: '#{body}'" unless body['errors']
+
+        raise Cloudflair::CloudflareError, body['errors']
       end
 
       body['result']
@@ -44,32 +47,32 @@ module Cloudflair
 
     def raise_on_http_error(status)
       case status
-      when 200..399 then
-      when 400..499 then
+      when 200..399
+      when 400..499
         raise_on_http_client_error status
-      when 500..599 then
-        fail Cloudflair::CloudflairError, "#{status} Remote Error"
+      when 500..599
+        raise Cloudflair::CloudflairError, "#{status} Remote Error"
       else
-        fail Cloudflair::CloudflairError, "#{status} Unknown Error Code"
+        raise Cloudflair::CloudflairError, "#{status} Unknown Error Code"
       end
     end
 
     def raise_on_http_client_error(status)
       case status
-      when 400 then
-        fail Cloudflair::CloudflairError, '400 Bad Request'
-      when 401 then
-        fail Cloudflair::CloudflairError, '401 Unauthorized'
-      when 403 then
-        fail Cloudflair::CloudflairError, '403 Forbidden'
-      when 405 then
-        fail Cloudflair::CloudflairError, '405 Method Not Allowed'
-      when 415 then
-        fail Cloudflair::CloudflairError, '415 Unsupported Media Type'
-      when 429 then
-        fail Cloudflair::CloudflairError, '429 Too Many Requests'
+      when 400
+        raise Cloudflair::CloudflairError, '400 Bad Request'
+      when 401
+        raise Cloudflair::CloudflairError, '401 Unauthorized'
+      when 403
+        raise Cloudflair::CloudflairError, '403 Forbidden'
+      when 405
+        raise Cloudflair::CloudflairError, '405 Method Not Allowed'
+      when 415
+        raise Cloudflair::CloudflairError, '415 Unsupported Media Type'
+      when 429
+        raise Cloudflair::CloudflairError, '429 Too Many Requests'
       else
-        fail Cloudflair::CloudflairError, "#{status} Request Error"
+        raise Cloudflair::CloudflairError, "#{status} Request Error"
       end
     end
 

--- a/lib/cloudflair/connection.rb
+++ b/lib/cloudflair/connection.rb
@@ -14,11 +14,12 @@ module Cloudflair
     def self.headers
       {}.tap do |request_headers|
         cloudflare_auth_config = Cloudflair.config.cloudflare.auth
+
         if !(cloudflare_auth_config.key.nil? || cloudflare_auth_config.email.nil?)
           request_headers['X-Auth-Key']   = cloudflare_auth_config.key
           request_headers['X-Auth-Email'] = cloudflare_auth_config.email
         elsif !cloudflare_auth_config.user_service_key.nil?
-          request_headers['Authentication'] = "Bearer #{cloudflare_auth_config.user_service_key}"
+          request_headers['Authorization'] = "Bearer #{cloudflare_auth_config.user_service_key}"
         else
           raise CloudflairError, 'Neither email & key nor user_service_key have been defined.'
         end

--- a/lib/cloudflair/connection.rb
+++ b/lib/cloudflair/connection.rb
@@ -12,22 +12,29 @@ module Cloudflair
       new_faraday_from config
     end
 
-    def self.headers
-      {}.tap do |request_headers|
-        cloudflare_auth_config = Cloudflair.config.cloudflare.auth
+    def self.headers # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      cloudflare_auth_config = Cloudflair.config.cloudflare.auth
 
-        if !(cloudflare_auth_config.key.nil? || cloudflare_auth_config.email.nil?)
-          request_headers['X-Auth-Key']   = cloudflare_auth_config.key
-          request_headers['X-Auth-Email'] = cloudflare_auth_config.email
-        elsif !cloudflare_auth_config.user_service_key.nil?
-          request_headers['Authorization'] = "Bearer #{cloudflare_auth_config.user_service_key}"
-        else
-          raise CloudflairError, 'Neither email & key nor user_service_key have been defined.'
-        end
+      if !cloudflare_auth_config.key.nil? && !cloudflare_auth_config.email.nil?
+        return({
+          'X-Auth-Key'   => cloudflare_auth_config.key,
+          'X-Auth-Email' => cloudflare_auth_config.email
+        })
       end
+
+      unless cloudflare_auth_config.user_service_key.nil?
+        return({
+          'Authorization' => "Bearer #{cloudflare_auth_config.user_service_key}"
+        })
+      end
+
+      raise(
+        CloudflairError,
+        'Neither email & key nor user_service_key have been defined.'
+      )
     end
 
-    private_class_method def self.new_faraday_from(config)
+    private_class_method def self.new_faraday_from(config) # rubocop:disable Metrics/AbcSize
       Faraday.new(url: config.cloudflare.api_base_url, headers: headers) do |faraday|
         faraday.request :json
         faraday.response config.faraday.logger if config.faraday.logger

--- a/lib/cloudflair/connection.rb
+++ b/lib/cloudflair/connection.rb
@@ -12,17 +12,17 @@ module Cloudflair
     end
 
     def self.headers
-      headers = {}
-      cloudflare_auth_config = Cloudflair.config.cloudflare.auth
-      if !(cloudflare_auth_config.key.nil? || cloudflare_auth_config.email.nil?)
-        headers['X-Auth-Key'] = cloudflare_auth_config.key
-        headers['X-Auth-Email'] = cloudflare_auth_config.email
-      elsif !cloudflare_auth_config.user_service_key.nil?
-        headers['X-Auth-User-Service-Key'] = cloudflare_auth_config.user_service_key
-      else
-        raise CloudflairError, 'Neither email & key nor user_service_key have been defined.'
+      {}.tap do |request_headers|
+        cloudflare_auth_config = Cloudflair.config.cloudflare.auth
+        if !(cloudflare_auth_config.key.nil? || cloudflare_auth_config.email.nil?)
+          request_headers['X-Auth-Key']   = cloudflare_auth_config.key
+          request_headers['X-Auth-Email'] = cloudflare_auth_config.email
+        elsif !cloudflare_auth_config.user_service_key.nil?
+          request_headers['Authentication'] = "Bearer #{cloudflare_auth_config.user_service_key}"
+        else
+          raise CloudflairError, 'Neither email & key nor user_service_key have been defined.'
+        end
       end
-      headers
     end
 
     private_class_method def self.new_faraday_from(config)

--- a/lib/cloudflair/connection.rb
+++ b/lib/cloudflair/connection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'faraday'
 require 'faraday_middleware'
 require 'faraday/detailed_logger'
@@ -7,7 +9,6 @@ module Cloudflair
   class Connection
     def self.new
       config = Cloudflair.config
-
       new_faraday_from config
     end
 

--- a/lib/cloudflair/entity.rb
+++ b/lib/cloudflair/entity.rb
@@ -18,13 +18,14 @@ module Cloudflair
       def patchable_fields(*fields)
         return @patchable_fields if @patchable_fields
 
-        @patchable_fields = if fields.nil?
-                              []
-                            elsif fields.is_a?(Array)
-                              fields.map(&:to_s)
-                            else
-                              [fields.to_s]
-                            end
+        @patchable_fields =
+          if fields.nil?
+            []
+          elsif fields.is_a?(Array)
+            fields.map(&:to_s)
+          else
+            [fields.to_s]
+          end
       end
 
       def deletable(deletable = false)
@@ -44,11 +45,12 @@ module Cloudflair
       def object_fields(*fields)
         return @object_fields if @object_fields
 
-        @object_fields = if fields.nil? || fields.empty?
-                           []
-                         else
-                           fields.map(&:to_s)
-                         end
+        @object_fields =
+          if fields.nil? || fields.empty?
+            []
+          else
+            fields.map(&:to_s)
+          end
       end
 
       # allowed values:
@@ -71,17 +73,17 @@ module Cloudflair
       end
 
       def turn_all_items_into_a_single_hash(fields_to_class_map)
-        fields_map = {}
-        fields_to_class_map.each do |field_definition|
-          if field_definition.is_a?(Hash)
-            fields_to_class_map[0].each do |field, klass_or_proc|
-              fields_map[field.to_s] = klass_or_proc
+        {}.tap do |fields_map|
+          fields_to_class_map.each do |field_definition|
+            if field_definition.is_a?(Hash)
+              fields_to_class_map[0].each do |field, klass_or_proc|
+                fields_map[field.to_s] = klass_or_proc
+              end
+            else
+              fields_map[field_definition.to_s] = nil
             end
-          else
-            fields_map[field_definition.to_s] = nil
           end
         end
-        fields_map
       end
     end
 
@@ -134,17 +136,15 @@ module Cloudflair
         if patchable_fields.include?(name[0..-2])
           dirty_data[name[0..-2]] = args[0]
           return
-        else
-          super
         end
+
+        super
       end
 
       # allow access to the unmodified data using 'zone.always_string!' or 'zone._name!'
       return data[name[0..2]] if name.end_with?('!') && data.key?(name[0..-2])
-
       return objectify(name) if object_fields.include? name
       return arrayify(name, array_object_fields[name]) if array_object_fields.key?(name)
-
       return dirty_data[name] if dirty_data.key?(name)
       return data[name] if data.is_a?(Hash) && data.key?(name)
 
@@ -155,13 +155,10 @@ module Cloudflair
       name = normalize_accessor name_as_symbol
 
       return true if name_as_symbol == :_raw_data!
-
       return true if name.end_with?('=') && patchable_fields.include?(name[0..-2])
       return true if name.end_with?('!') && data.key?(name[0..-2])
-
       return true if object_fields.include? name
       return true if array_object_fields.key?(name)
-
       return true if dirty_data.key?(name)
       return true if data.is_a?(Hash) && data.key?(name)
 
@@ -235,9 +232,11 @@ module Cloudflair
 
     def replace_path_variables_in(path)
       interpreted_path = path.clone
+
       path.scan(/:([a-zA-Z_][a-zA-Z0-9_]+[!?=]?)/) do |match, *|
-        interpreted_path.gsub! ":#{match}", send(match).to_s
+        interpreted_path = interpreted_path.gsub ":#{match}", send(match).to_s
       end
+
       interpreted_path
     end
 

--- a/lib/cloudflair/error/cloudflair_error.rb
+++ b/lib/cloudflair/error/cloudflair_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cloudflair
   class CloudflairError < StandardError
   end

--- a/lib/cloudflair/error/cloudflare_error.rb
+++ b/lib/cloudflair/error/cloudflare_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cloudflair
   class CloudflareError < StandardError
     attr_reader :cloudflare_errors

--- a/lib/cloudflair/version.rb
+++ b/lib/cloudflair/version.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 module Cloudflair
 end

--- a/spec/cloudflair/api/railguns_spec.rb
+++ b/spec/cloudflair/api/railguns_spec.rb
@@ -1,10 +1,13 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Railguns do
+  subject { Cloudflair.railgun railgun_identifier }
+
   let(:railgun_identifier) { 'e928d310693a83094309acf9ead50448' }
   let(:response_json) { File.read('spec/cloudflair/fixtures/railgun/railgun.json') }
   let(:url) { "/client/v4/railguns/#{railgun_identifier}" }
-  subject { Cloudflair.railgun railgun_identifier }
 
   before do
     faraday_stubs.get(url) do |_env|
@@ -57,6 +60,7 @@ describe Cloudflair::Railguns do
 
   describe '#delete' do
     let(:response_json) { File.read('spec/cloudflair/fixtures/railgun/delete.json') }
+
     before do
       faraday_stubs.delete(url) do |_env|
         [200, { content_type: 'application/json' }, response_json]
@@ -77,14 +81,15 @@ describe Cloudflair::Railguns do
   end
 
   describe '#zones' do
+    subject { Cloudflair.railgun(railgun_identifier).zones }
+
     let(:url) { "/client/v4/railguns/#{railgun_identifier}/zones" }
     let(:response_json) { File.read('spec/cloudflair/fixtures/railgun/railgun_zones.json') }
-    subject { Cloudflair.railgun(railgun_identifier).zones }
 
     it 'fetches the associated zones' do
       expect(faraday).to receive(:get).and_call_original
 
-      expect(subject).to_not be_nil
+      expect(subject).not_to be_nil
       expect(subject).to be_an Array
     end
 

--- a/spec/cloudflair/api/zone/analytics_spec.rb
+++ b/spec/cloudflair/api/zone/analytics_spec.rb
@@ -1,8 +1,11 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::DnsRecord do
-  let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
   subject(:analytics) { Cloudflair.zone(zone_identifier).analytics }
+
+  let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
 
   before do
     faraday_stubs.get(url) do |_env|
@@ -12,15 +15,16 @@ describe Cloudflair::DnsRecord do
   end
 
   describe '#dashboard' do
+    subject { analytics.dashboard }
+
     let(:response_json) { File.read('spec/cloudflair/fixtures/zone/analytics_dashboard.json') }
     let(:url) { "/client/v4/zones/#{zone_identifier}/analytics/dashboard" }
-    subject { analytics.dashboard }
 
     it 'fetches the values' do
       expect(faraday).to receive(:get).and_call_original
 
-      expect(subject).to_not be_nil
-      expect(subject).to_not be_a Hash
+      expect(subject).not_to be_nil
+      expect(subject).not_to be_a Hash
     end
 
     it 'does not cache the response' do
@@ -29,31 +33,32 @@ describe Cloudflair::DnsRecord do
       a = analytics.dashboard
       b = analytics.dashboard
 
-      expect(a).to_not be_nil
-      expect(b).to_not be_nil
+      expect(a).not_to be_nil
+      expect(b).not_to be_nil
 
-      expect(a).to_not be b
-      expect(b).to_not be a
+      expect(a).not_to be b
+      expect(b).not_to be a
     end
 
     it 'returns the actual values' do
-      expect(subject.totals).to_not be_nil
+      expect(subject.totals).not_to be_nil
       expect(subject.totals).to be_a Hash
-      expect(subject.totals['requests']['all']).to be 1234085328
-      expect(subject.timeseries).to_not be_nil
+      expect(subject.totals['requests']['all']).to be 1_234_085_328
+      expect(subject.timeseries).not_to be_nil
       expect(subject.timeseries.length).to be 1
     end
   end
 
   describe '#colos' do
+    subject { analytics.colos }
+
     let(:response_json) { File.read('spec/cloudflair/fixtures/zone/analytics_colos.json') }
     let(:url) { "/client/v4/zones/#{zone_identifier}/analytics/colos" }
-    subject { analytics.colos }
 
     it 'fetches the values' do
       expect(faraday).to receive(:get).and_call_original
 
-      expect(subject).to_not be_nil
+      expect(subject).not_to be_nil
       expect(subject).to be_an Array
     end
 
@@ -63,18 +68,18 @@ describe Cloudflair::DnsRecord do
       a = analytics.colos
       b = analytics.colos
 
-      expect(a).to_not be_nil
-      expect(b).to_not be_nil
+      expect(a).not_to be_nil
+      expect(b).not_to be_nil
 
-      expect(a).to_not be b
-      expect(b).to_not be a
+      expect(a).not_to be b
+      expect(b).not_to be a
     end
 
     it 'returns the actual values' do
       expect(subject.length).to be 1
-      expect(subject[0]).to_not be_a Hash
+      expect(subject[0]).not_to be_a Hash
       expect(subject[0].colo_id).to eq 'SFO'
-      expect(subject[0].timeseries).to_not be_nil
+      expect(subject[0].timeseries).not_to be_nil
       expect(subject[0].timeseries.length).to be 1
     end
   end

--- a/spec/cloudflair/api/zone/available_plan_spec.rb
+++ b/spec/cloudflair/api/zone/available_plan_spec.rb
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::AvailablePlan do
+  subject { Cloudflair.zone(zone_identifier).available_plan(plan_identifier) }
+
   let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
   let(:plan_identifier) { 'e592fd9519420ba7405e1307bff33214' }
   let(:response_json) { File.read('spec/cloudflair/fixtures/zone/plan.json') }
   let(:url) { "/client/v4/zones/#{zone_identifier}/available_plans/#{plan_identifier}" }
-  subject { Cloudflair.zone(zone_identifier).available_plan(plan_identifier) }
 
   before do
     faraday_stubs.get(url) do |_env|

--- a/spec/cloudflair/api/zone/available_rate_plan_spec.rb
+++ b/spec/cloudflair/api/zone/available_rate_plan_spec.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::AvailableRatePlan do
   let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
   let(:response_json) { File.read('spec/cloudflair/fixtures/zone/available_rate_plans.json') }
   let(:url) { "/client/v4/zones/#{zone_identifier}/available_rate_plans" }
-  let(:subject) { Cloudflair::AvailableRatePlan.new zone_identifier }
+  let(:subject) { described_class.new zone_identifier }
 
   before do
     faraday_stubs.get(url) do |_env|
@@ -30,7 +32,7 @@ describe Cloudflair::AvailableRatePlan do
     expect(components.length).to be 1
 
     component = components[0]
-    expect(component).to_not be_a Hash
+    expect(component).not_to be_a Hash
     expect(component.name).to eq 'page_rules'
     expect(component.default).to be 5
     expect(component.unit_price).to be 1

--- a/spec/cloudflair/api/zone/custom_hostname_spec.rb
+++ b/spec/cloudflair/api/zone/custom_hostname_spec.rb
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::CustomHostname do
+  subject { Cloudflair.zone(zone_identifier).custom_hostname(hostname_identifier) }
+
   let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
   let(:hostname_identifier) { '0d89c70d-ad9f-4843-b99f-6cc0252067e9' }
   let(:response_json) { File.read('spec/cloudflair/fixtures/zone/custom_hostname.json') }
   let(:url) { "/client/v4/zones/#{zone_identifier}/custom_hostnames/#{hostname_identifier}" }
-  subject { Cloudflair.zone(zone_identifier).custom_hostname(hostname_identifier) }
 
   before do
     faraday_stubs.get(url) do |_env|

--- a/spec/cloudflair/api/zone/dns_record_spec.rb
+++ b/spec/cloudflair/api/zone/dns_record_spec.rb
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::DnsRecord do
+  subject { Cloudflair.zone(zone_identifier).dns_record(record_identifier) }
+
   let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
   let(:record_identifier) { '372e67954025e0ba6aaa6d586b9e0b59' }
   let(:response_json) { File.read('spec/cloudflair/fixtures/zone/dns_record.json') }
   let(:url) { "/client/v4/zones/#{zone_identifier}/dns_records/#{record_identifier}" }
-  subject { Cloudflair.zone(zone_identifier).dns_record(record_identifier) }
 
   before do
     faraday_stubs.get(url) do |_env|

--- a/spec/cloudflair/api/zone/purge_cache_spec.rb
+++ b/spec/cloudflair/api/zone/purge_cache_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'faraday/detailed_logger'
 

--- a/spec/cloudflair/api/zone/railgun_spec.rb
+++ b/spec/cloudflair/api/zone/railgun_spec.rb
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Railgun do
+  subject(:railgun) { Cloudflair.zone(zone_identifier).railgun(railgun_identifier) }
+
   let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
   let(:railgun_identifier) { 'e928d310693a83094309acf9ead50448' }
   let(:response_json) { File.read('spec/cloudflair/fixtures/zone/railgun.json') }
   let(:url) { "/client/v4/zones/#{zone_identifier}/railguns/#{railgun_identifier}" }
-  subject(:railgun) { Cloudflair.zone(zone_identifier).railgun(railgun_identifier) }
 
   before do
     faraday_stubs.get(url) do |_env|
@@ -40,8 +43,8 @@ describe Cloudflair::Railgun do
     it 'calls the diagnose endpoint' do
       expect(faraday).to receive(:get).and_call_original
 
-      expect(railgun).to_not be_nil
-      expect(railgun).to_not be_a Hash
+      expect(railgun).not_to be_nil
+      expect(railgun).not_to be_a Hash
     end
 
     it 'returns the right values' do

--- a/spec/cloudflair/api/zone/settings/advanced_ddos_spec.rb
+++ b/spec/cloudflair/api/zone/settings/advanced_ddos_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::AdvancedDdos do
@@ -32,7 +34,7 @@ describe Cloudflair::AdvancedDdos do
   # non-standard
   describe 'put values' do
     it 'does not save the value' do
-      expect(faraday).to_not receive(:patch)
+      expect(faraday).not_to receive(:patch)
 
       expect { subject.value = new_value }.to raise_error NoMethodError
 

--- a/spec/cloudflair/api/zone/settings/always_online_spec.rb
+++ b/spec/cloudflair/api/zone/settings/always_online_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::AlwaysOnline do

--- a/spec/cloudflair/api/zone/settings/browser_cache_ttl_spec.rb
+++ b/spec/cloudflair/api/zone/settings/browser_cache_ttl_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::BrowserCacheTtl do
@@ -7,7 +9,7 @@ describe Cloudflair::BrowserCacheTtl do
   let(:subject) { Cloudflair.zone(zone_identifier).settings.public_send setting_identifier }
 
   let(:setting_identifier) { 'browser_cache_ttl' }
-  let(:value) { 14400 }
+  let(:value) { 14_400 }
   let(:new_value) { 7200 }
 
   before do

--- a/spec/cloudflair/api/zone/settings/browser_check_spec.rb
+++ b/spec/cloudflair/api/zone/settings/browser_check_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::BrowserCheck do

--- a/spec/cloudflair/api/zone/settings/cache_level_spec.rb
+++ b/spec/cloudflair/api/zone/settings/cache_level_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::CacheLevel do

--- a/spec/cloudflair/api/zone/settings/challenge_ttl_spec.rb
+++ b/spec/cloudflair/api/zone/settings/challenge_ttl_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::ChallengeTtl do
@@ -8,7 +10,7 @@ describe Cloudflair::ChallengeTtl do
 
   let(:setting_identifier) { 'challenge_ttl' }
   let(:value) { 1800 }
-  let(:new_value) { 605800 }
+  let(:new_value) { 605_800 }
 
   before do
     faraday_stubs.get(url) do |_env|

--- a/spec/cloudflair/api/zone/settings/development_mode_spec.rb
+++ b/spec/cloudflair/api/zone/settings/development_mode_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::DevelopmentMode do

--- a/spec/cloudflair/api/zone/settings/email_obfuscation_spec.rb
+++ b/spec/cloudflair/api/zone/settings/email_obfuscation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::EmailObfuscation do

--- a/spec/cloudflair/api/zone/settings/hotlink_protection_spec.rb
+++ b/spec/cloudflair/api/zone/settings/hotlink_protection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::HotlinkProtection do

--- a/spec/cloudflair/api/zone/settings/ip_geolocation_spec.rb
+++ b/spec/cloudflair/api/zone/settings/ip_geolocation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::IpGeolocation do

--- a/spec/cloudflair/api/zone/settings/ipv6_spec.rb
+++ b/spec/cloudflair/api/zone/settings/ipv6_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Ipv6 do

--- a/spec/cloudflair/api/zone/settings/minify_spec.rb
+++ b/spec/cloudflair/api/zone/settings/minify_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Minify do

--- a/spec/cloudflair/api/zone/settings/mirage_spec.rb
+++ b/spec/cloudflair/api/zone/settings/mirage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Mirage do

--- a/spec/cloudflair/api/zone/settings/mobile_redirect_spec.rb
+++ b/spec/cloudflair/api/zone/settings/mobile_redirect_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::MobileRedirect do

--- a/spec/cloudflair/api/zone/settings/origin_error_page_pass_thru_spec.rb
+++ b/spec/cloudflair/api/zone/settings/origin_error_page_pass_thru_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::OriginErrorPagePassThru do
@@ -31,7 +33,7 @@ describe Cloudflair::OriginErrorPagePassThru do
   # non-standard
   describe 'put values' do
     it 'does not save the value' do
-      expect(faraday).to_not receive(:patch)
+      expect(faraday).not_to receive(:patch)
 
       expect { subject.value = new_value }.to raise_error NoMethodError
 

--- a/spec/cloudflair/api/zone/settings/polish_spec.rb
+++ b/spec/cloudflair/api/zone/settings/polish_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Polish do

--- a/spec/cloudflair/api/zone/settings/prefetch_preload_spec.rb
+++ b/spec/cloudflair/api/zone/settings/prefetch_preload_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::PrefetchPreload do

--- a/spec/cloudflair/api/zone/settings/response_buffering_spec.rb
+++ b/spec/cloudflair/api/zone/settings/response_buffering_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::ResponseBuffering do

--- a/spec/cloudflair/api/zone/settings/rocket_loader_spec.rb
+++ b/spec/cloudflair/api/zone/settings/rocket_loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::RocketLoader do

--- a/spec/cloudflair/api/zone/settings/security_header_spec.rb
+++ b/spec/cloudflair/api/zone/settings/security_header_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::SecurityHeader do
@@ -10,12 +12,12 @@ describe Cloudflair::SecurityHeader do
   let(:value) do
     {
       'strict_transport_security' =>
-        {
-          'enabled' => true,
-          'max_age' => 86400,
-          'include_subdomains' => true,
-          'nosniff' => true,
-        },
+                                     {
+                                       'enabled'            => true,
+                                       'max_age'            => 86_400,
+                                       'include_subdomains' => true,
+                                       'nosniff'            => true
+                                     }
     }
   end
   let(:new_value) { { 'strict_transport_security' => { 'enabled' => false } } }

--- a/spec/cloudflair/api/zone/settings/security_level_spec.rb
+++ b/spec/cloudflair/api/zone/settings/security_level_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::SecurityLevel do

--- a/spec/cloudflair/api/zone/settings/server_side_exclude_spec.rb
+++ b/spec/cloudflair/api/zone/settings/server_side_exclude_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::ServerSideExclude do

--- a/spec/cloudflair/api/zone/settings/sort_query_string_for_cache_spec.rb
+++ b/spec/cloudflair/api/zone/settings/sort_query_string_for_cache_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::SortQueryStringForCache do
@@ -31,7 +33,7 @@ describe Cloudflair::SortQueryStringForCache do
   # non-standard
   describe 'put values' do
     it 'does not save the value' do
-      expect(faraday).to_not receive(:patch)
+      expect(faraday).not_to receive(:patch)
 
       expect { subject.value = new_value }.to raise_error NoMethodError
 

--- a/spec/cloudflair/api/zone/settings/ssl_spec.rb
+++ b/spec/cloudflair/api/zone/settings/ssl_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Ssl do

--- a/spec/cloudflair/api/zone/settings/tls_1_2_only_spec.rb
+++ b/spec/cloudflair/api/zone/settings/tls_1_2_only_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Tls12Only do

--- a/spec/cloudflair/api/zone/settings/tls_1_3_spec.rb
+++ b/spec/cloudflair/api/zone/settings/tls_1_3_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Tls13 do

--- a/spec/cloudflair/api/zone/settings/tls_client_auth_spec.rb
+++ b/spec/cloudflair/api/zone/settings/tls_client_auth_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::TlsClientAuth do

--- a/spec/cloudflair/api/zone/settings/true_client_ip_header_spec.rb
+++ b/spec/cloudflair/api/zone/settings/true_client_ip_header_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::TrueClientIpHeader do

--- a/spec/cloudflair/api/zone/settings/waf_spec.rb
+++ b/spec/cloudflair/api/zone/settings/waf_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Waf do

--- a/spec/cloudflair/api/zone/settings/websockets_spec.rb
+++ b/spec/cloudflair/api/zone/settings/websockets_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Ssl do

--- a/spec/cloudflair/api/zone/settings_spec.rb
+++ b/spec/cloudflair/api/zone/settings_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Settings do
@@ -10,36 +12,36 @@ describe Cloudflair::Settings do
   end
 
   {
-    always_online: Cloudflair::AlwaysOnline,
-    advanced_ddos: Cloudflair::AdvancedDdos,
-    browser_cache_ttl: Cloudflair::BrowserCacheTtl,
-    browser_check: Cloudflair::BrowserCheck,
-    cache_level: Cloudflair::CacheLevel,
-    challenge_ttl: Cloudflair::ChallengeTtl,
-    development_mode: Cloudflair::DevelopmentMode,
-    email_obfuscation: Cloudflair::EmailObfuscation,
-    hotlink_protection: Cloudflair::HotlinkProtection,
-    ip_geolocation: Cloudflair::IpGeolocation,
-    ipv6: Cloudflair::Ipv6,
-    minify: Cloudflair::Minify,
-    mirage: Cloudflair::Mirage,
-    mobile_redirect: Cloudflair::MobileRedirect,
+    always_online:               Cloudflair::AlwaysOnline,
+    advanced_ddos:               Cloudflair::AdvancedDdos,
+    browser_cache_ttl:           Cloudflair::BrowserCacheTtl,
+    browser_check:               Cloudflair::BrowserCheck,
+    cache_level:                 Cloudflair::CacheLevel,
+    challenge_ttl:               Cloudflair::ChallengeTtl,
+    development_mode:            Cloudflair::DevelopmentMode,
+    email_obfuscation:           Cloudflair::EmailObfuscation,
+    hotlink_protection:          Cloudflair::HotlinkProtection,
+    ip_geolocation:              Cloudflair::IpGeolocation,
+    ipv6:                        Cloudflair::Ipv6,
+    minify:                      Cloudflair::Minify,
+    mirage:                      Cloudflair::Mirage,
+    mobile_redirect:             Cloudflair::MobileRedirect,
     origin_error_page_pass_thru: Cloudflair::OriginErrorPagePassThru,
-    polish: Cloudflair::Polish,
-    prefetch_preload: Cloudflair::PrefetchPreload,
-    response_buffering: Cloudflair::ResponseBuffering,
-    rocket_loader: Cloudflair::RocketLoader,
-    security_header: Cloudflair::SecurityHeader,
-    security_level: Cloudflair::SecurityLevel,
-    server_side_exclude: Cloudflair::ServerSideExclude,
+    polish:                      Cloudflair::Polish,
+    prefetch_preload:            Cloudflair::PrefetchPreload,
+    response_buffering:          Cloudflair::ResponseBuffering,
+    rocket_loader:               Cloudflair::RocketLoader,
+    security_header:             Cloudflair::SecurityHeader,
+    security_level:              Cloudflair::SecurityLevel,
+    server_side_exclude:         Cloudflair::ServerSideExclude,
     sort_query_string_for_cache: Cloudflair::SortQueryStringForCache,
-    ssl: Cloudflair::Ssl,
-    tls_client_auth: Cloudflair::TlsClientAuth,
-    tls_1_2_only: Cloudflair::Tls12Only,
-    tls_1_3: Cloudflair::Tls13,
-    true_client_ip_header: Cloudflair::TrueClientIpHeader,
-    waf: Cloudflair::Waf,
-    websockets: Cloudflair::Websockets,
+    ssl:                         Cloudflair::Ssl,
+    tls_client_auth:             Cloudflair::TlsClientAuth,
+    tls_1_2_only:                Cloudflair::Tls12Only,
+    tls_1_3:                     Cloudflair::Tls13,
+    true_client_ip_header:       Cloudflair::TrueClientIpHeader,
+    waf:                         Cloudflair::Waf,
+    websockets:                  Cloudflair::Websockets
   }.each do |method, klass|
     it "returns an initialized #{method} object" do
       expect(subject.public_send(method)).to be_a klass

--- a/spec/cloudflair/api/zone__available_plans_spec.rb
+++ b/spec/cloudflair/api/zone__available_plans_spec.rb
@@ -1,13 +1,16 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Zone, 'available_plans things' do
+  subject { Cloudflair.zone zone_identifier }
+
   before do
     allow(Faraday).to receive(:new).and_return faraday
   end
 
   let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
   let(:url) { "/client/v4/zones/#{zone_identifier}/dns_records" }
-  subject { Cloudflair.zone zone_identifier }
 
   describe '#available_plan' do
     it 'returns an AvailablePlan instance' do

--- a/spec/cloudflair/api/zone__custom_hostnames_spec.rb
+++ b/spec/cloudflair/api/zone__custom_hostnames_spec.rb
@@ -1,13 +1,16 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Zone, 'custom_hostname things' do
+  subject(:zone) { Cloudflair.zone zone_identifier }
+
   before do
     allow(Faraday).to receive(:new).and_return faraday
   end
 
   let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
   let(:url) { "/client/v4/zones/#{zone_identifier}/custom_hostnames" }
-  subject(:zone) { Cloudflair.zone zone_identifier }
 
   describe '#custom_hostname' do
     it 'returns a Custom Hostname instance' do
@@ -16,7 +19,7 @@ describe Cloudflair::Zone, 'custom_hostname things' do
   end
 
   describe '#new_custom_hostname=' do
-    let(:new_custom_hostname_data) { { hostname: 'app.example.com', ssl: {method: 'http', type: 'dv', settings: {http2: 'on', min_tls_version: '1.2', tls_1_3: 'on', ciphers: ['ECDHE-RSA-AES128-GCM-SHA256', 'AES128-SHA']}}} }
+    let(:new_custom_hostname_data) { { hostname: 'app.example.com', ssl: { method: 'http', type: 'dv', settings: { http2: 'on', min_tls_version: '1.2', tls_1_3: 'on', ciphers: %w[ECDHE-RSA-AES128-GCM-SHA256 AES128-SHA] } } } }
     let(:response_json) { File.read('spec/cloudflair/fixtures/zone/custom_hostname.json') }
     let(:the_new_custom_hostname) { subject.new_custom_hostname(new_custom_hostname_data) }
 
@@ -33,7 +36,7 @@ describe Cloudflair::Zone, 'custom_hostname things' do
     end
 
     it 'prepopulates the returned CustomHostname instance' do
-      expect(faraday).to_not receive(:get)
+      expect(faraday).not_to receive(:get)
 
       expect(the_new_custom_hostname.id).to eq('0d89c70d-ad9f-4843-b99f-6cc0252067e9')
       expect(the_new_custom_hostname.hostname).to eq('app.example.com')
@@ -42,8 +45,9 @@ describe Cloudflair::Zone, 'custom_hostname things' do
   end
 
   describe '#custom_hostnames' do
-    let(:response_json) { File.read('spec/cloudflair/fixtures/zone/custom_hostnames.json') }
     subject { zone.custom_hostnames }
+
+    let(:response_json) { File.read('spec/cloudflair/fixtures/zone/custom_hostnames.json') }
 
     before do
       faraday_stubs.get(url) do |_env|

--- a/spec/cloudflair/api/zone__dns_records_spec.rb
+++ b/spec/cloudflair/api/zone__dns_records_spec.rb
@@ -1,13 +1,16 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Zone, 'dns_record things' do
+  subject(:zone) { Cloudflair.zone zone_identifier }
+
   before do
     allow(Faraday).to receive(:new).and_return faraday
   end
 
   let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
   let(:url) { "/client/v4/zones/#{zone_identifier}/dns_records" }
-  subject(:zone) { Cloudflair.zone zone_identifier }
 
   describe '#dns_record' do
     it 'returns a DnsRecord instance' do
@@ -33,7 +36,7 @@ describe Cloudflair::Zone, 'dns_record things' do
     end
 
     it 'prepopulates the returned DnsRecord instance' do
-      expect(faraday).to_not receive(:get)
+      expect(faraday).not_to receive(:get)
 
       expect(the_new_dns_record.id).to eq('372e67954025e0ba6aaa6d586b9e0b59')
       expect(the_new_dns_record.ttl).to be 120
@@ -42,8 +45,9 @@ describe Cloudflair::Zone, 'dns_record things' do
   end
 
   describe '#dns_records' do
-    let(:response_json) { File.read('spec/cloudflair/fixtures/zone/dns_records.json') }
     subject { zone.dns_records }
+
+    let(:response_json) { File.read('spec/cloudflair/fixtures/zone/dns_records.json') }
 
     before do
       faraday_stubs.get(url) do |_env|

--- a/spec/cloudflair/api/zone__railguns_spec.rb
+++ b/spec/cloudflair/api/zone__railguns_spec.rb
@@ -1,6 +1,10 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Zone, 'railguns things' do
+  subject(:zone) { Cloudflair.zone zone_identifier }
+
   before do
     allow(Faraday).to receive(:new).and_return faraday
     faraday_stubs.get(url) do |_env|
@@ -11,7 +15,6 @@ describe Cloudflair::Zone, 'railguns things' do
   let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
   let(:response_json) { File.read('spec/cloudflair/fixtures/zone/railguns.json') }
   let(:url) { "/client/v4/zones/#{zone_identifier}/railguns" }
-  subject(:zone) { Cloudflair.zone zone_identifier }
 
   describe '#railgun' do
     it 'returns a DnsRecord instance' do

--- a/spec/cloudflair/api/zone_spec.rb
+++ b/spec/cloudflair/api/zone_spec.rb
@@ -1,10 +1,13 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Zone do
+  subject { Cloudflair.zone zone_identifier }
+
   let(:zone_identifier) { '023e105f4ecef8ad9ca31a8372d0c353' }
   let(:response_json) { File.read('spec/cloudflair/fixtures/zone/details.json') }
   let(:url) { "/client/v4/zones/#{zone_identifier}" }
-  subject { Cloudflair.zone zone_identifier }
 
   before do
     faraday_stubs.get(url) do |_env|
@@ -58,7 +61,7 @@ describe Cloudflair::Zone do
 
     context '#plan' do
       it 'returns the plan as actual object' do
-        expect(subject.plan).to_not be_a Hash
+        expect(subject.plan).not_to be_a Hash
       end
 
       it 'passes all the values to the plan object' do
@@ -76,7 +79,7 @@ describe Cloudflair::Zone do
 
     context '#plan_pending' do
       it 'returns the pending plan as actual object' do
-        expect(subject.plan_pending).to_not be_a Hash
+        expect(subject.plan_pending).not_to be_a Hash
       end
 
       it 'passes all the values to the plan_pending object' do
@@ -95,7 +98,7 @@ describe Cloudflair::Zone do
 
     context '#owner' do
       it 'returns the `owner` as actual object' do
-        expect(subject.owner).to_not be_a Hash
+        expect(subject.owner).not_to be_a Hash
       end
 
       it 'passes all the value to the `owner` object' do
@@ -145,6 +148,7 @@ describe Cloudflair::Zone do
 
   describe '#delete' do
     let(:response_json) { File.read('spec/cloudflair/fixtures/zone/delete.json') }
+
     before do
       faraday_stubs.delete(url) do |_env|
         [200, { content_type: 'application/json' }, response_json]

--- a/spec/cloudflair/api_railguns_spec.rb
+++ b/spec/cloudflair/api_railguns_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair, 'railguns' do
@@ -5,7 +7,7 @@ describe Cloudflair, 'railguns' do
 
   describe '#railgun' do
     it 'returns a railgun object' do
-      expect(subject.railgun(railgun_identifier)).to_not be_nil
+      expect(subject.railgun(railgun_identifier)).not_to be_nil
       expect(subject.railgun(railgun_identifier)).to be_a Cloudflair::Railguns
     end
 
@@ -17,8 +19,8 @@ describe Cloudflair, 'railguns' do
       a = subject.railgun railgun_identifier
       b = subject.railgun railgun_identifier
 
-      expect(a).to_not be_nil
-      expect(b).to_not be_nil
+      expect(a).not_to be_nil
+      expect(b).not_to be_nil
 
       expect(a).to be_a Cloudflair::Railguns
       expect(b).to be_a Cloudflair::Railguns
@@ -26,8 +28,8 @@ describe Cloudflair, 'railguns' do
       expect(a.railgun_id).to eq railgun_identifier
       expect(b.railgun_id).to eq railgun_identifier
 
-      expect(a).to_not be b
-      expect(b).to_not be a
+      expect(a).not_to be b
+      expect(b).not_to be a
     end
   end
 
@@ -78,8 +80,8 @@ describe Cloudflair, 'railguns' do
       it 'calls the remote side with the query params' do
         expect(faraday).to receive(:get).and_call_original
 
-        subject.railguns page: 1,
-                         per_page: 20,
+        subject.railguns page:      1,
+                         per_page:  20,
                          direction: 'desc'
       end
     end

--- a/spec/cloudflair/api_zones_spec.rb
+++ b/spec/cloudflair/api_zones_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair, 'zones' do
@@ -5,7 +7,7 @@ describe Cloudflair, 'zones' do
 
   describe '#zone' do
     it 'returns a zone object' do
-      expect(subject.zone(zone_identifier)).to_not be_nil
+      expect(subject.zone(zone_identifier)).not_to be_nil
       expect(subject.zone(zone_identifier)).to be_a Cloudflair::Zone
     end
 
@@ -17,8 +19,8 @@ describe Cloudflair, 'zones' do
       a = subject.zone zone_identifier
       b = subject.zone zone_identifier
 
-      expect(a).to_not be_nil
-      expect(b).to_not be_nil
+      expect(a).not_to be_nil
+      expect(b).not_to be_nil
 
       expect(a).to be_a Cloudflair::Zone
       expect(b).to be_a Cloudflair::Zone
@@ -26,8 +28,8 @@ describe Cloudflair, 'zones' do
       expect(a.zone_id).to eq zone_identifier
       expect(b.zone_id).to eq zone_identifier
 
-      expect(a).to_not be b
-      expect(b).to_not be a
+      expect(a).not_to be b
+      expect(b).not_to be a
     end
   end
 
@@ -90,6 +92,7 @@ describe Cloudflair, 'zones' do
           subject.zones name: 'Hello'
         end
       end
+
       context 'all combined' do
         let(:url_query) do
           'match=all&name=example.com&order=desc&page=1&per_page=20&status=active'
@@ -98,12 +101,12 @@ describe Cloudflair, 'zones' do
         it 'calls the remote side with the query params' do
           expect(faraday).to receive(:get).and_call_original
 
-          subject.zones name: 'example.com',
-                        status: 'active',
-                        page: 1,
+          subject.zones name:     'example.com',
+                        status:   'active',
+                        page:     1,
                         per_page: 20,
-                        order: 'desc',
-                        match: 'all'
+                        order:    'desc',
+                        match:    'all'
         end
       end
     end

--- a/spec/cloudflair/cloudflair_spec.rb
+++ b/spec/cloudflair/cloudflair_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair do
@@ -6,7 +8,7 @@ describe Cloudflair do
   end
 
   it 'is configurable' do
-    Cloudflair.configure do |config|
+    described_class.configure do |config|
       config.cloudflare.auth.key = 'MY_AUTH_KEY'
       config.cloudflare.auth.email = 'MY_AUTH_EMAIL'
       config.cloudflare.auth.user_service_key = 'MY_AUTH_USER_SERVICE_KEY'
@@ -14,10 +16,10 @@ describe Cloudflair do
       config.faraday.adapter = :net_http_persistent
     end
 
-    expect(Cloudflair.config.cloudflare.auth.key).to eq 'MY_AUTH_KEY'
-    expect(Cloudflair.config.cloudflare.auth.email).to eq 'MY_AUTH_EMAIL'
-    expect(Cloudflair.config.cloudflare.auth.user_service_key).to eq 'MY_AUTH_USER_SERVICE_KEY'
-    expect(Cloudflair.config.cloudflare.api_base_url).to eq 'https://cloudflair.mock.local'
-    expect(Cloudflair.config.faraday.adapter).to be :net_http_persistent
+    expect(described_class.config.cloudflare.auth.key).to eq 'MY_AUTH_KEY'
+    expect(described_class.config.cloudflare.auth.email).to eq 'MY_AUTH_EMAIL'
+    expect(described_class.config.cloudflare.auth.user_service_key).to eq 'MY_AUTH_USER_SERVICE_KEY'
+    expect(described_class.config.cloudflare.api_base_url).to eq 'https://cloudflair.mock.local'
+    expect(described_class.config.faraday.adapter).to be :net_http_persistent
   end
 end

--- a/spec/cloudflair/communication_spec.rb
+++ b/spec/cloudflair/communication_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'json'
 
@@ -7,6 +9,7 @@ describe Cloudflair::Communication do
   let(:response) { double('response', body: response_body, status: 200) }
 
   let(:subject) { Victim.new }
+
   class Victim
     include Cloudflair::Communication
   end
@@ -31,8 +34,8 @@ describe Cloudflair::Communication do
       '{"name":"Beat","boolean":true,"number":1,"float_number":1.2,"date":"2014-05-28T18:46:18.764425Z"}'
     end
     let(:response_body) do
-      JSON.
-        parse(
+      JSON
+        .parse(
           '{"success":true,"errors":[],"messages":[],"result":' +
             result_json +
             ',"result_info":{"page":1,"per_page":20,"count":1,"total_count":2000}}'
@@ -60,8 +63,8 @@ describe Cloudflair::Communication do
     end
 
     it 'raises the appropriate exception' do
-      expect { subject.response(response) }.
-        to raise_error(Cloudflair::CloudflareError, '[ "Invalid or missing zone id." (Code: 1003) ]')
+      expect { subject.response(response) }
+        .to raise_error(Cloudflair::CloudflareError, '[ "Invalid or missing zone id." (Code: 1003) ]')
     end
   end
 

--- a/spec/cloudflair/connection_spec.rb
+++ b/spec/cloudflair/connection_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'uri'
 
@@ -15,29 +17,29 @@ describe Cloudflair::Connection do
     end
 
     it 'returns a Faraday::Connection' do
-      expect(Cloudflair::Connection.new).to be_a Faraday::Connection
+      expect(described_class.new).to be_a Faraday::Connection
     end
 
     it 'correctly sets the base url' do
-      expect(Cloudflair::Connection.new.url_prefix).
-        to eq(URI.parse('https://cloudflair.mock.local'))
+      expect(described_class.new.url_prefix)
+        .to eq(URI.parse('https://cloudflair.mock.local'))
     end
 
     it 'sets the correct auth headers' do
-      actual_headers = Cloudflair::Connection.new.headers
+      actual_headers = described_class.new.headers
       expect(actual_headers['X-Auth-Key']).to eq 'c2547eb745079dac9320b638f5e225cf483cc5cfdda41'
       expect(actual_headers['X-Auth-Email']).to eq 'user@example.com'
       expect(actual_headers['X-Auth-User-Service-Key']).to be_nil
     end
 
     it 'sets the adapter' do
-      expect(Cloudflair::Connection.new.builder.handlers).
-        to include Faraday::Adapter::NetHttp
+      expect(described_class.new.builder.handlers)
+        .to include Faraday::Adapter::NetHttp
     end
 
     it 'adds the json middleware' do
-      expect(Cloudflair::Connection.new.builder.handlers).
-        to include FaradayMiddleware::ParseJson
+      expect(described_class.new.builder.handlers)
+        .to include FaradayMiddleware::ParseJson
     end
   end
 
@@ -53,10 +55,10 @@ describe Cloudflair::Connection do
     end
 
     it 'sets the correct auth headers' do
-      actual_headers = Cloudflair::Connection.new.headers
+      actual_headers = described_class.new.headers
       expect(actual_headers['X-Auth-Key']).to be_nil
       expect(actual_headers['X-Auth-Email']).to be_nil
-      expect(actual_headers['X-Auth-User-Service-Key']).to eq 'v1.0-e24fd090c02efcfecb4de8f4ff246fd5c75b48946fdf0ce26c59f91d0d90797b-cfa33fe60e8e34073c149323454383fc9005d25c9b4c502c2f063457ef65322eade065975001a0b4b4c591c5e1bd36a6e8f7e2d4fa8a9ec01c64c041e99530c2-07b9efe0acd78c82c8d9c690aacb8656d81c369246d7f996a205fe3c18e9254a'
+      expect(actual_headers['Authorization']).to eq 'Bearer v1.0-e24fd090c02efcfecb4de8f4ff246fd5c75b48946fdf0ce26c59f91d0d90797b-cfa33fe60e8e34073c149323454383fc9005d25c9b4c502c2f063457ef65322eade065975001a0b4b4c591c5e1bd36a6e8f7e2d4fa8a9ec01c64c041e99530c2-07b9efe0acd78c82c8d9c690aacb8656d81c369246d7f996a205fe3c18e9254a'
     end
   end
 
@@ -69,8 +71,8 @@ describe Cloudflair::Connection do
     end
 
     it 'sets the adapter' do
-      expect(Cloudflair::Connection.new.builder.handlers).
-        to include Faraday::Adapter::NetHttpPersistent
+      expect(described_class.new.builder.handlers)
+        .to include Faraday::Adapter::NetHttpPersistent
     end
   end
 
@@ -85,8 +87,8 @@ describe Cloudflair::Connection do
       end
 
       it 'sets the logger' do
-        expect(Cloudflair::Connection.new.builder.handlers).
-          to include Faraday::Response::Logger
+        expect(described_class.new.builder.handlers)
+          .to include Faraday::Response::Logger
       end
     end
 
@@ -100,8 +102,8 @@ describe Cloudflair::Connection do
       end
 
       it 'sets the logger' do
-        expect(Cloudflair::Connection.new.builder.handlers).
-          to include Faraday::DetailedLogger::Middleware
+        expect(described_class.new.builder.handlers)
+          .to include Faraday::DetailedLogger::Middleware
       end
     end
   end

--- a/spec/cloudflair/entity_array_objectfields_spec.rb
+++ b/spec/cloudflair/entity_array_objectfields_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Entity do
@@ -112,7 +114,7 @@ describe Cloudflair::Entity do
       it 'does not return `an_object_array` as Hashes' do
         expect(subject.an_object_array).to be_a Array
         subject.an_object_array.each do |obj|
-          expect(obj).to_not be_a Hash
+          expect(obj).not_to be_a Hash
         end
       end
 
@@ -128,15 +130,15 @@ describe Cloudflair::Entity do
         expect(faraday).to receive(:get).once.and_call_original
 
         expect(subject._name).to eq 'Beat'
-        expect(subject.an_object_array).to_not be_a Hash
+        expect(subject.an_object_array).not_to be_a Hash
       end
 
       it 'is a new object everytime' do
         a = subject.an_object_array
         b = subject.an_object_array
 
-        expect(a).to_not be b
-        expect(b).to_not be a
+        expect(a).not_to be b
+        expect(b).not_to be a
       end
     end
 
@@ -162,15 +164,15 @@ describe Cloudflair::Entity do
         expect(faraday).to receive(:get).once.and_call_original
 
         expect(subject._name).to eq 'Beat'
-        expect(subject.an_object_array).to_not be_a Hash
+        expect(subject.an_object_array).not_to be_a Hash
       end
 
       it 'is a new object everytime' do
         a = subject.an_object_array
         b = subject.an_object_array
 
-        expect(a).to_not be b
-        expect(b).to_not be a
+        expect(a).not_to be b
+        expect(b).not_to be a
       end
     end
 
@@ -196,15 +198,15 @@ describe Cloudflair::Entity do
         expect(faraday).to receive(:get).once.and_call_original
 
         expect(subject._name).to eq 'Beat'
-        expect(subject.an_object_array).to_not be_a Hash
+        expect(subject.an_object_array).not_to be_a Hash
       end
 
       it 'is a new object everytime' do
         a = subject.an_object_array
         b = subject.an_object_array
 
-        expect(a).to_not be b
-        expect(b).to_not be a
+        expect(a).not_to be b
+        expect(b).not_to be a
       end
     end
   end

--- a/spec/cloudflair/entity_spec.rb
+++ b/spec/cloudflair/entity_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::Entity do
@@ -51,21 +53,21 @@ describe Cloudflair::Entity do
   end
   let(:raw_data) do
     {
-      'name' => 'Beat',
-      'boolean' => true,
-      'number' => 1,
-      'float_number' => 1.2,
-      'date' => '2014-05-28T18:46:18.764425Z',
-      'an_object' => {
-        'key' => 'value',
-        'second' => 2,
+      'name'            => 'Beat',
+      'boolean'         => true,
+      'number'          => 1,
+      'float_number'    => 1.2,
+      'date'            => '2014-05-28T18:46:18.764425Z',
+      'an_object'       => {
+        'key'    => 'value',
+        'second' => 2
       },
-      'an_array' => [],
+      'an_array'        => [],
       'an_object_array' => [
         { 'name' => 'obj1' },
         { 'name' => 'obj2' },
-        { 'name' => 'obj3' },
-      ],
+        { 'name' => 'obj3' }
+      ]
     }
   end
   let(:response_json) do
@@ -179,13 +181,13 @@ describe Cloudflair::Entity do
     end
 
     it 'does not send PATCH to the server when nothing changed' do
-      expect(faraday).to_not receive(:patch)
+      expect(faraday).not_to receive(:patch)
 
       expect(subject.patch).to be subject
     end
 
     it 'does not send PATCH to the server when nothing valid changed' do
-      expect(faraday).to_not receive(:patch)
+      expect(faraday).not_to receive(:patch)
 
       expect(subject.update(illegal: 'It Is')).to be subject
     end
@@ -201,7 +203,7 @@ describe Cloudflair::Entity do
     end
 
     it 'does not send PATCH' do
-      expect(faraday).to_not receive(:patch)
+      expect(faraday).not_to receive(:patch)
 
       expect(subject.update(name: 'Fritz')).to be subject
     end
@@ -215,6 +217,7 @@ describe Cloudflair::Entity do
     let(:response_json) do
       '{"success":true,"errors":[],"messages":[],"result":{"id":42}}'
     end
+
     before do
       faraday_stubs.delete(url) do |_env|
         [200, { content_type: 'application/json' }, response_json]
@@ -242,6 +245,7 @@ describe Cloudflair::Entity do
 
     context 'non-deletable entity' do
       let(:subject) { TestEntity2.new }
+
       it 'raises an error' do
         expect { subject.delete }.to raise_error Cloudflair::CloudflairError
       end
@@ -266,11 +270,11 @@ describe Cloudflair::Entity do
 
   describe 'objectification of fields' do
     it 'does not return `an_object` as Hash' do
-      expect(subject.an_object).to_not be_a Hash
+      expect(subject.an_object).not_to be_a Hash
     end
 
     it 'returns the correct values' do
-      expect(subject.an_object).to_not be_a Hash
+      expect(subject.an_object).not_to be_a Hash
       expect(subject.an_object.key).to eq 'value'
       expect(subject.an_object.second).to be 2
     end
@@ -279,15 +283,15 @@ describe Cloudflair::Entity do
       expect(faraday).to receive(:get).once.and_call_original
 
       expect(subject._name).to eq 'Beat'
-      expect(subject.an_object).to_not be_a Hash
+      expect(subject.an_object).not_to be_a Hash
     end
 
     it 'is a new object everytime' do
       a = subject.an_object
       b = subject.an_object
 
-      expect(a).to_not be b
-      expect(b).to_not be a
+      expect(a).not_to be b
+      expect(b).not_to be a
     end
   end
 end

--- a/spec/cloudflair/error/cloudflare_error_spec.rb
+++ b/spec/cloudflair/error/cloudflare_error_spec.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Cloudflair::CloudflareError do
   let(:cloudflare_errors) do
     [
-      { 'code' => 1003, 'message' => 'Invalid or missing zone id.' },
+      { 'code' => 1003, 'message' => 'Invalid or missing zone id.' }
     ]
   end
-  let(:subject) { Cloudflair::CloudflareError.new cloudflare_errors }
+  let(:subject) { described_class.new cloudflare_errors }
 
   it 'serializes the given errors' do
     expect(subject.to_s).to eq '[ "Invalid or missing zone id." (Code: 1003) ]'
@@ -16,13 +18,13 @@ describe Cloudflair::CloudflareError do
     let(:cloudflare_errors) do
       [
         { 'code' => 1003, 'message' => 'Invalid or missing zone id.' },
-        { 'code' => 1003, 'message' => 'Invalid or missing zone id.' },
+        { 'code' => 1003, 'message' => 'Invalid or missing zone id.' }
       ]
     end
 
     it 'serializes the given errors' do
-      expect(subject.to_s).
-        to eq '[ "Invalid or missing zone id." (Code: 1003), "Invalid or missing zone id." (Code: 1003) ]'
+      expect(subject.to_s)
+        .to eq '[ "Invalid or missing zone id." (Code: 1003), "Invalid or missing zone id." (Code: 1003) ]'
     end
   end
 end

--- a/spec/shared_context.rb
+++ b/spec/shared_context.rb
@@ -1,29 +1,43 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 require 'cloudflair'
 require 'faraday'
 require 'faraday_middleware'
+require 'faraday/detailed_logger'
 
 RSpec.shared_context 'connection setup' do
-  let(:faraday_logger) { nil }
-  let(:cloudflare_auth) { { key: 'test_api_key', email: 'test_account_email', user_service_key: nil } }
   let(:cloudflare_api_base_url) { 'https://api.cloudflare.com/client/v4/' }
 
-  let(:faraday_stubs) { Faraday::Adapter::Test::Stubs.new }
+  let(:cloudflare_auth) do
+    {
+      key:              'test_api_key',
+      email:            'test_account_email',
+      user_service_key: nil
+    }
+  end
+
   let(:faraday) do
-    Faraday.new(url: Cloudflair.config.cloudflare.api_base_url, headers: Cloudflair::Connection.headers) do |faraday|      
+    Faraday.new(
+      url:     Cloudflair.config.cloudflare.api_base_url,
+      headers: Cloudflair::Connection.headers
+    ) do |faraday|
       faraday.response :json, content_type: /\bjson$/
-      faraday.request faraday_logger if faraday_logger
+      faraday.response faraday_logger if faraday_logger
       faraday.adapter :test, faraday_stubs
     end
   end
 
+  let(:faraday_logger) { :detailed_logger }
+  let(:faraday_stubs) { Faraday::Adapter::Test::Stubs.new }
+
   before do
     Cloudflair.configure do |config|
-      config.cloudflare.auth.key = cloudflare_auth[:key]
-      config.cloudflare.auth.email = cloudflare_auth[:email]
+      config.cloudflare.auth.key              = cloudflare_auth[:key]
+      config.cloudflare.auth.email            = cloudflare_auth[:email]
       config.cloudflare.auth.user_service_key = cloudflare_auth[:user_service_key]
-      config.cloudflare.api_base_url = cloudflare_api_base_url
+      config.cloudflare.api_base_url          = cloudflare_api_base_url
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,6 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'shared_context'
 


### PR DESCRIPTION
This PR has two things: 
* A bunch of Rubocop changes 
* A new authentication header in lib/cloudflair/connection.rb, which uses a token to replace the email address and key.  

I am also able to use this code to update a DNS record, which is reported as an Issue in this repo. 