### PR TITLE
add attributes 'name_servers' and 'name' to Zone class

### DIFF
--- a/lib/cloudflair/api/zone.rb
+++ b/lib/cloudflair/api/zone.rb
@@ -42,5 +42,13 @@ module Cloudflair
     def analytics
       Cloudflair::Analytics.new zone_id
     end
+
+    def name_servers
+      data.fetch('name_servers', [])
+    end
+
+    def name
+      data.fetch('name', '')
+    end
   end
 end


### PR DESCRIPTION
this will fix issues in `cockpit` where these fields are referenced